### PR TITLE
remove react-tap-event-plugin, deprecated and unneeded in react 16.4

### DIFF
--- a/app/assets/javascripts/app.js
+++ b/app/assets/javascripts/app.js
@@ -18,8 +18,6 @@ import 'babel-polyfill';
 import React, { Component, PropTypes } from 'react';
 import { render } from 'react-dom'
 
-import injectTapEventPlugin from 'react-tap-event-plugin';
-
 import ThemeManager from 'material-ui/lib/styles/theme-manager';
 
 import FirstVoicesTheme from 'views/themes/FirstVoicesTheme.js';
@@ -37,8 +35,6 @@ require('!style-loader!css-loader!alloyeditor/dist/alloy-editor/assets/alloy-edi
 require('!style-loader!css-loader!tether-shepherd/dist/css/shepherd-theme-arrows.css');
 require('bootstrap/less/bootstrap');
 require("styles/main");
-
-injectTapEventPlugin();
 
 const context = {
     providers,

--- a/app/assets/javascripts/views/components/Document/DocumentListView/index.js
+++ b/app/assets/javascripts/views/components/Document/DocumentListView/index.js
@@ -25,10 +25,6 @@ import Paper from 'material-ui/lib/paper';
 
 import withPagination from 'views/hoc/grid-list/with-pagination';
 
-// is TapEvent needed here?! Test on mobile
-//var injectTapEventPlugin = require("react-tap-event-plugin");
-//injectTapEventPlugin();
-
 // Stylesheet
 import '!style-loader!css-loader!react-datagrid/dist/index.min.css';
 

--- a/app/assets/javascripts/views/components/Legacy/GameWrapperView/Games/MultiQuiz/AnswerMQ/index.js
+++ b/app/assets/javascripts/views/components/Legacy/GameWrapperView/Games/MultiQuiz/AnswerMQ/index.js
@@ -22,8 +22,6 @@ var {RaisedButton} = Mui;
 
 var WordOperations = require('operations/WordOperations');
 
-var injectTapEventPlugin = require("react-tap-event-plugin");
-
 // https://github.com/facebook/react/issues/3451#issuecomment-83000311
 var ThemeManager = new Mui.Styles.ThemeManager();
 
@@ -31,12 +29,6 @@ class AnswerMQ extends React.Component {
 
   constructor(props) {
     super(props);
-
-    //Needed for onTouchTap
-    //Can go away when react 1.0 release
-    //Check this repo:
-    //https://github.com/zilverline/react-tap-event-plugin
-    injectTapEventPlugin();
 
     this.eventName = "ANSWERMQ";
 
@@ -105,7 +97,7 @@ class AnswerMQ extends React.Component {
 
     return <div className="col-xs-6">
       <div className={classNames('imgContAnswer', (this.props.selected) ? 'selectedImgContAnswer' : '')}>
-        {(this.state.image != null) ? <img onTouchTap={this._handleClick} className="image" src={this.state.image} alt=""/> : 'Loading...' }
+        {(this.state.image != null) ? <img onClick={this._handleClick} className="image" src={this.state.image} alt=""/> : 'Loading...' }
       </div>
       <audio src={this.state.audio} className="audio" id={(this.state.answer != undefined) ? this.state.answer.uid + '-audio' : ''} type="audio/mp4" preload="auto" />
     </div>;

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "react-paginate": "^4.1.1",
     "react-redux": "~4.4.5",
     "react-redux-provide": "git+ssh://git@github.com/First-Peoples-Cultural-Council/react-redux-provide.git#v5.2.3",
-    "react-tap-event-plugin": "~0.2.0",
     "redux": "~3.5.2",
     "redux-logger": "~3.0.6",
     "redux-thunk": "~2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3582,14 +3582,6 @@ faye-websocket@~0.11.0:
   dependencies:
     websocket-driver ">=0.5.1"
 
-fbjs@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.2.1.tgz#622061630a43e11f845017b9044aaa648ed3f731"
-  dependencies:
-    core-js "^1.0.0"
-    promise "^7.0.3"
-    whatwg-fetch "^0.9.0"
-
 fbjs@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.6.1.tgz#9636b7705f5ba9684d44b72f78321254afc860f7"
@@ -7824,12 +7816,6 @@ react-style-normalizer@^1.2.0, react-style-normalizer@^1.2.6, react-style-normal
 react-swipeable@^3.5.1:
   version "3.9.2"
   resolved "https://registry.yarnpkg.com/react-swipeable/-/react-swipeable-3.9.2.tgz#bbaab62688b1aed4a4f73830d272eedd168f3627"
-
-react-tap-event-plugin@~0.2.0:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/react-tap-event-plugin/-/react-tap-event-plugin-0.2.2.tgz#4f6f257851654f6c2b1c213a1d3ff21b353ae4e1"
-  dependencies:
-    fbjs "^0.2.1"
 
 react-themeable@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
This removes `react-tap-event-plugin` from the dependency list and removes its use in the code base. Any `onTapTouch` was changed to `onClick`