### PR TITLE
Update styles and themes

### DIFF
--- a/app/assets/javascripts/views/components/Browsing/category-list.js
+++ b/app/assets/javascripts/views/components/Browsing/category-list.js
@@ -20,8 +20,6 @@ import selectn from 'selectn';
 
 import ConfGlobal from 'conf/local.json';
 
-import * as Colors from 'material-ui/styles/colors';
-
 import GridList from '@material-ui/core/GridList';
 import GridListTile from '@material-ui/core/GridListTile';
 import GridListTileBar from '@material-ui/core/GridListTileBar';

--- a/app/assets/javascripts/views/components/Browsing/media-list.js
+++ b/app/assets/javascripts/views/components/Browsing/media-list.js
@@ -20,8 +20,6 @@ import selectn from 'selectn';
 
 import ConfGlobal from 'conf/local.json';
 
-import * as Colors from 'material-ui/styles/colors';
-
 import GridList from '@material-ui/core/GridList';
 import GridListTile from '@material-ui/core/GridListTile';
 import GridListTileBar from '@material-ui/core/GridListTileBar';

--- a/app/assets/javascripts/views/components/Browsing/portal-list.js
+++ b/app/assets/javascripts/views/components/Browsing/portal-list.js
@@ -18,7 +18,7 @@ import PropTypes from 'prop-types';
 import Immutable, {List, Map} from 'immutable';
 import selectn from 'selectn';
 
-import * as Colors from 'material-ui/styles/colors';
+import * as Colors from '@material-ui/core/colors';
 
 import GridList from '@material-ui/core/GridList';
 import GridListTile from '@material-ui/core/GridListTile';

--- a/app/assets/javascripts/views/pages/content/index.js
+++ b/app/assets/javascripts/views/pages/content/index.js
@@ -21,8 +21,6 @@ import provide from 'react-redux-provide';
 import selectn from 'selectn';
 import classNames from 'classnames';
 
-import * as Colors from 'material-ui/styles/colors';
-
 import ProviderHelpers from 'common/ProviderHelpers';
 import StringHelpers from 'common/StringHelpers';
 

--- a/app/assets/javascripts/views/pages/explore/dialect/learn/base/grid-view.js
+++ b/app/assets/javascripts/views/pages/explore/dialect/learn/base/grid-view.js
@@ -21,8 +21,6 @@ import classNames from 'classnames';
 
 import ConfGlobal from 'conf/local.json';
 
-import * as Colors from 'material-ui/styles/colors';
-
 import GridList from '@material-ui/core/GridList';
 import GridListTile from '@material-ui/core/GridListTile';
 import GridListTileBar from '@material-ui/core/GridListTileBar';

--- a/app/assets/javascripts/views/pages/explore/dialect/play/wordscramble/index.js
+++ b/app/assets/javascripts/views/pages/explore/dialect/play/wordscramble/index.js
@@ -19,7 +19,7 @@ import ReactDOM from 'react-dom';
 import Immutable, {List, Map} from 'immutable';
 
 import Button from '@material-ui/core/Button';
-import * as Colors from 'material-ui/styles/colors';
+import * as Colors from '@material-ui/core/colors';
 import IconButton from '@material-ui/core/IconButton';
 import AVPlayArrow from '@material-ui/icons/PlayArrow';
 import CheckBoxIcon from '@material-ui/icons/CheckBox';

--- a/app/assets/javascripts/views/pages/home/index.js
+++ b/app/assets/javascripts/views/pages/home/index.js
@@ -21,8 +21,6 @@ import provide from 'react-redux-provide';
 import selectn from 'selectn';
 import classNames from 'classnames';
 
-import * as Colors from 'material-ui/styles/colors';
-
 import ProviderHelpers from 'common/ProviderHelpers';
 
 import PromiseWrapper from 'views/components/Document/PromiseWrapper';

--- a/app/assets/javascripts/views/themes/FirstVoicesKidsTheme.js
+++ b/app/assets/javascripts/views/themes/FirstVoicesKidsTheme.js
@@ -1,7 +1,7 @@
-import * as Colors from 'material-ui/styles/colors';
-import * as ColorManipulator from 'material-ui/utils/colorManipulator';
-import Spacing from 'material-ui/styles/spacing';
-import zIndex from 'material-ui/styles/zIndex';
+import * as Colors from '@material-ui/core/colors';
+import * as ColorManipulator from '@material-ui/core/styles/colorManipulator';
+import Spacing from '@material-ui/core/styles/spacing';
+import zIndex from '@material-ui/core/styles/zIndex';
 
 export default {
   spacing: Spacing,
@@ -18,7 +18,7 @@ export default {
     alternateTextColor: Colors.white,
     canvasColor: Colors.white,
     borderColor: Colors.grey300,
-    disabledColor: ColorManipulator.fade(Colors.darkBlack, 0.3),
+    disabledColor: ColorManipulator.fade('#000000', 0.3),
     pickerHeaderColor: Colors.cyan500
   },
   wrapper: {

--- a/app/assets/javascripts/views/themes/FirstVoicesTheme.js
+++ b/app/assets/javascripts/views/themes/FirstVoicesTheme.js
@@ -1,7 +1,7 @@
-import * as Colors from 'material-ui/styles/colors';
-import * as ColorManipulator from 'material-ui/utils/colorManipulator';
-import Spacing from 'material-ui/styles/spacing';
-import zIndex from 'material-ui/styles/zIndex';
+import * as Colors from '@material-ui/core/colors';
+import * as ColorManipulator from '@material-ui/core/styles/colorManipulator';
+import Spacing from '@material-ui/core/styles/spacing';
+import zIndex from '@material-ui/core/styles/zIndex';
 
 export default {
   spacing: Spacing,
@@ -22,7 +22,7 @@ export default {
     alternateTextColor: Colors.white,
     canvasColor: Colors.white,
     borderColor: Colors.grey300,
-    disabledColor: ColorManipulator.fade(Colors.darkBlack, 0.3),
+    disabledColor: ColorManipulator.fade('#000000', 0.3),
     pickerHeaderColor: "#b40000"
   }
 };

--- a/app/assets/javascripts/views/themes/FirstVoicesWorkspaceTheme.js
+++ b/app/assets/javascripts/views/themes/FirstVoicesWorkspaceTheme.js
@@ -1,7 +1,7 @@
-import * as Colors from 'material-ui/styles/colors';
-import * as ColorManipulator from 'material-ui/utils/colorManipulator';
-import Spacing from 'material-ui/styles/spacing';
-import zIndex from 'material-ui/styles/zIndex';
+import * as Colors from '@material-ui/core/colors';
+import * as ColorManipulator from '@material-ui/core/styles/colorManipulator';
+import Spacing from '@material-ui/core/styles/spacing';
+import zIndex from '@material-ui/core/styles/zIndex';
 
 export default {
   spacing: Spacing,
@@ -18,7 +18,7 @@ export default {
     alternateTextColor: Colors.white,
     canvasColor: Colors.white,
     borderColor: Colors.grey300,
-    disabledColor: ColorManipulator.fade(Colors.darkBlack, 0.3),
+    disabledColor: ColorManipulator.fade('#000000', 0.3),
     pickerHeaderColor: Colors.teal400
   },
   wrapper: {


### PR DESCRIPTION
Updates imports for colors and styles. Still uses `getMuiTheme` from the old material-ui because the new way to provide a theme to components with a `<MuiThemeProvider />` won't work with the current setup of providing a theme through `react-redux-provide`.