### PR TITLE
Remove material ui

### DIFF
--- a/app/assets/javascripts/__tests__/test.js
+++ b/app/assets/javascripts/__tests__/test.js
@@ -4,7 +4,7 @@ import expect from 'expect';
 import providers from '../providers/index';
 import ConfGlobal from 'conf/local.json';
 import AppWrapper from '../views/AppWrapper';
-import getMuiTheme from 'material-ui/styles/getMuiTheme';
+import { createMuiTheme } from '@material-ui/core/styles';
 import FirstVoicesTheme from '../views/themes/FirstVoicesTheme.js';
 
 const context = {
@@ -15,7 +15,7 @@ const context = {
           pageTitleParams: null,
           domain: ConfGlobal.domain,
           theme: {
-              palette: getMuiTheme(FirstVoicesTheme),
+              palette: createMuiTheme(FirstVoicesTheme),
               id: 'default'
           }
       }

--- a/app/assets/javascripts/app.js
+++ b/app/assets/javascripts/app.js
@@ -19,7 +19,6 @@ import React, { Component} from 'react';
 import PropTypes from 'prop-types';
 import { render } from 'react-dom'
 
-import getMuiTheme from 'material-ui/styles/getMuiTheme';
 import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles'
 
 import FirstVoicesTheme from 'views/themes/FirstVoicesTheme.js';
@@ -65,7 +64,7 @@ const props = {
                     pageTitleParams: null,
                     domain: ConfGlobal.domain,
                     theme: {
-                        palette: getMuiTheme(FirstVoicesTheme),
+                        palette: createMuiTheme(FirstVoicesTheme),
                         id: 'default'
                     }
                 }

--- a/app/assets/javascripts/providers/navigation.js
+++ b/app/assets/javascripts/providers/navigation.js
@@ -2,7 +2,7 @@
 //import createLoggerMiddleware from 'redux-logger';
 import thunk from 'redux-thunk';
 
-import getMuiTheme from 'material-ui/styles/getMuiTheme';
+import { createMuiTheme } from '@material-ui/core/styles';
 
 import FirstVoicesTheme from 'views/themes/FirstVoicesTheme.js';
 import FirstVoicesKidsTheme from 'views/themes/FirstVoicesKidsTheme.js';
@@ -90,15 +90,15 @@ const actions = {
   // Change theme
   changeTheme(id) {
 
-    let theme = getMuiTheme(FirstVoicesTheme);
+    let theme = createMuiTheme(FirstVoicesTheme);
 
     switch (id) {
       case 'kids':
-        theme = getMuiTheme(FirstVoicesKidsTheme);
+        theme = createMuiTheme(FirstVoicesKidsTheme);
       break;
 
       case 'workspace':
-        theme = getMuiTheme(FirstVoicesWorkspaceTheme);
+        theme = createMuiTheme(FirstVoicesWorkspaceTheme);
       break;
     }
 

--- a/app/assets/javascripts/views/AppFrontController.js
+++ b/app/assets/javascripts/views/AppFrontController.js
@@ -1437,8 +1437,7 @@ export default class AppFrontController extends Component {
     }
 
     _renderWithBreadcrumb(reactElement, matchedPage, props, theme) {
-
-        const themePalette = props.properties.theme.palette.rawTheme.palette;
+        const themePalette = props.properties.theme.palette.palette;
 
         return (
             <div>

--- a/app/assets/javascripts/views/components/Editor/Preview.js
+++ b/app/assets/javascripts/views/components/Editor/Preview.js
@@ -248,7 +248,7 @@ export default class Preview extends Component {
 
     render() {
 
-        const themePalette = this.props.properties.theme.palette.rawTheme.palette;
+        const themePalette = this.props.properties.theme.palette.palette;
 
         let handleExpandChange = () => {
         };

--- a/app/assets/javascripts/views/components/Navigation/Login/index.js
+++ b/app/assets/javascripts/views/components/Navigation/Login/index.js
@@ -126,7 +126,7 @@ export default class Login extends Component {
 
     render() {
 
-        const themePalette = this.props.properties.theme.palette.rawTheme.palette;
+        const themePalette = this.props.properties.theme.palette.palette;
         const TextFieldStyle = {
             border: '1px solid',
             borderColor: '#a2291d',

--- a/app/assets/javascripts/views/components/Navigation/index.js
+++ b/app/assets/javascripts/views/components/Navigation/index.js
@@ -296,7 +296,7 @@ export default class Navigation extends Component {
   }
 
   render() {
-    const themePalette = this.props.properties.theme.palette.rawTheme.palette;
+    const themePalette = this.props.properties.theme.palette.palette;
     const isDialect = this.props.routeParams.hasOwnProperty('dialect_path');
     const isFrontPage = this.props.frontpage;
 

--- a/app/assets/javascripts/views/pages/explore/dialect/learn/base/metadata-panel.js
+++ b/app/assets/javascripts/views/pages/explore/dialect/learn/base/metadata-panel.js
@@ -135,7 +135,7 @@ export default class MetadataPanel extends Component {
             value: selectn("response.properties.uid:major_version", computeEntity) + '.' + selectn("response.properties.uid:minor_version", computeEntity)
         });
 
-        const themePalette = this.props.properties.theme.palette.rawTheme.palette;
+        const themePalette = this.props.properties.theme.palette.palette;
 
         return <Card initiallyExpanded={false}>
             <CardHeader

--- a/app/assets/javascripts/views/pages/explore/dialect/learn/index.js
+++ b/app/assets/javascripts/views/pages/explore/dialect/learn/index.js
@@ -281,7 +281,7 @@ export default class DialectLearn extends Component {
                 });
         }
 
-        const themePalette = this.props.properties.theme.palette.rawTheme.palette;
+        const themePalette = this.props.properties.theme.palette.palette;
 
         return <PromiseWrapper computeEntities={computeEntities}>
 

--- a/app/assets/javascripts/views/pages/explore/dialect/page-toolbar.js
+++ b/app/assets/javascripts/views/pages/explore/dialect/page-toolbar.js
@@ -155,7 +155,6 @@ export default class PageToolbar extends Component {
     }
 
     render() {
-
         const {computeEntity, computePermissionEntity, computeLogin} = this.props;
 
         let enableTasks = [];
@@ -165,7 +164,6 @@ export default class PageToolbar extends Component {
 
         let toolbarGroupItem = {
             float: 'left',
-            margin: `${(this.context.muiTheme.toolbar.height - this.context.muiTheme.button.height) / 2}px ${this.context.muiTheme.baseTheme.spacing.desktopGutter}px`,
             position: 'relative'
         }
 

--- a/app/assets/javascripts/views/pages/users/login/index.js
+++ b/app/assets/javascripts/views/pages/users/login/index.js
@@ -120,7 +120,7 @@ export default class PageUserLogin extends Component {
 
     _returnLoginFormContent() {
 
-        const themePalette = this.props.properties.theme.palette.rawTheme.palette;
+        const themePalette = this.props.properties.theme.palette.palette;
         const TextFieldStyle = {
             border: '1px solid',
             borderColor: '#a2291d',

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "expose-loader": "^0.7.1",
     "immutable": "~3.8.2",
     "leaflet": "^1.0.3",
-    "material-ui": "0.20.1",
     "merge-stream": "~0.1.8",
     "normalize.css": "~3.0.3",
     "nuxeo": "~0.24.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -66,13 +66,6 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
-"@babel/runtime@7.0.0-beta.42":
-  version "7.0.0-beta.42"
-  resolved "http://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0-beta.42.tgz#352e40c92e0460d3e82f49bd7e79f6cda76f919f"
-  dependencies:
-    core-js "^2.5.3"
-    regenerator-runtime "^0.11.1"
-
 "@babel/runtime@7.0.0-rc.1":
   version "7.0.0-rc.1"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0-rc.1.tgz#42f36fc5817911c89ea75da2b874054922967616"
@@ -1318,7 +1311,7 @@ babel-register@^6.26.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.15"
 
-babel-runtime@^6.0.0, babel-runtime@^6.18.0, babel-runtime@^6.2.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0, babel-runtime@^6.26.0, babel-runtime@~6.26.0:
+babel-runtime@^6.0.0, babel-runtime@^6.18.0, babel-runtime@^6.2.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0, babel-runtime@~6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:
@@ -1578,10 +1571,6 @@ bootstrap-webpack@0.0.3:
 bootstrap@^3.3.7:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.3.7.tgz#5a389394549f23330875a3b150656574f8a9eb71"
-
-bowser@^1.7.3:
-  version "1.9.4"
-  resolved "https://registry.yarnpkg.com/bowser/-/bowser-1.9.4.tgz#890c58a2813a9d3243704334fa81b96a5c150c9a"
 
 brace-expansion@^1.0.0, brace-expansion@^1.1.7:
   version "1.1.11"
@@ -1957,10 +1946,6 @@ chai@~3.2.0:
     assertion-error "^1.0.1"
     deep-eql "^0.1.3"
     type-detect "^1.0.0"
-
-chain-function@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/chain-function/-/chain-function-1.0.1.tgz#c63045e5b4b663fb86f1c6e186adaf1de402a1cc"
 
 chalk@^0.4.0:
   version "0.4.0"
@@ -2416,10 +2401,6 @@ core-js@^2.1.0, core-js@^2.4.0, core-js@^2.5.0:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.3.tgz#8acc38345824f16d8365b7c9b4259168e8ed603e"
 
-core-js@^2.5.3:
-  version "2.5.7"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
-
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -2514,13 +2495,6 @@ crypto-browserify@^3.11.0:
     public-encrypt "^4.0.0"
     randombytes "^2.0.0"
     randomfill "^1.0.3"
-
-css-in-js-utils@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz#3b472b398787291b47cfe3e44fecfdd9e914ba99"
-  dependencies:
-    hyphenate-style-name "^1.0.2"
-    isobject "^3.0.1"
 
 css-loader@~0.14.5:
   version "0.14.5"
@@ -2972,7 +2946,7 @@ diffie-hellman@^5.0.0:
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
 
-dom-helpers@^3.2.0, dom-helpers@^3.2.1, dom-helpers@^3.3.1:
+dom-helpers@^3.2.1, dom-helpers@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.3.1.tgz#fc1a4e15ffdf60ddde03a480a9c0fece821dd4a6"
 
@@ -5230,13 +5204,6 @@ ini@^1.3.2, ini@^1.3.4, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
 
-inline-style-prefixer@^3.0.8:
-  version "3.0.8"
-  resolved "https://registry.yarnpkg.com/inline-style-prefixer/-/inline-style-prefixer-3.0.8.tgz#8551b8e5b4d573244e66a34b04f7d32076a2b534"
-  dependencies:
-    bowser "^1.7.3"
-    css-in-js-utils "^2.0.0"
-
 interpret@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
@@ -5937,7 +5904,7 @@ karma@~0.13.19:
     source-map "^0.5.3"
     useragent "^2.1.6"
 
-keycode@^2.1.8, keycode@^2.1.9:
+keycode@^2.1.9:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/keycode/-/keycode-2.2.0.tgz#3d0af56dc7b8b8e5cba8d0a97f107204eec22b04"
 
@@ -6334,10 +6301,6 @@ lodash.merge@^3.3.1:
     lodash.keysin "^3.0.0"
     lodash.toplainobject "^3.0.0"
 
-lodash.merge@^4.6.0:
-  version "4.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.1.tgz#adc25d9cb99b9391c59624f379fbba60d7111d54"
-
 lodash.restparam@^3.0.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
@@ -6541,22 +6504,6 @@ map-visit@^1.0.0:
   resolved "https://registry.yarnpkg.com/map-visit/-/map-visit-1.0.0.tgz#ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
   dependencies:
     object-visit "^1.0.0"
-
-material-ui@0.20.1:
-  version "0.20.1"
-  resolved "https://registry.yarnpkg.com/material-ui/-/material-ui-0.20.1.tgz#a0f0f9f801be76a13cf3da9b319a1b97b28925c7"
-  dependencies:
-    babel-runtime "^6.23.0"
-    inline-style-prefixer "^3.0.8"
-    keycode "^2.1.8"
-    lodash.merge "^4.6.0"
-    lodash.throttle "^4.1.1"
-    prop-types "^15.5.7"
-    react-event-listener "^0.5.1"
-    react-transition-group "^1.2.1"
-    recompose "^0.26.0"
-    simple-assign "^0.1.0"
-    warning "^3.0.0"
 
 md5.js@^1.3.4:
   version "1.3.4"
@@ -7713,14 +7660,14 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10, prop-types@^15.5.6, prop-types@^15.5.8, prop-types@^15.6.1, prop-types@^15.6.2:
+prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.1, prop-types@^15.6.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
   dependencies:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-prop-types@^15.5.4, prop-types@^15.5.7, prop-types@^15.6.0:
+prop-types@^15.5.4, prop-types@^15.6.0:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
   dependencies:
@@ -8004,15 +7951,6 @@ react-dom@^16.2.0, react-dom@^16.4.2:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-react-event-listener@^0.5.1:
-  version "0.5.10"
-  resolved "https://registry.yarnpkg.com/react-event-listener/-/react-event-listener-0.5.10.tgz#378403c555fe616f312891507a742ecbbe2c90de"
-  dependencies:
-    "@babel/runtime" "7.0.0-beta.42"
-    fbjs "^0.8.16"
-    prop-types "^15.6.0"
-    warning "^3.0.0"
-
 react-event-listener@^0.6.2:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/react-event-listener/-/react-event-listener-0.6.3.tgz#8eab88129a76e095ed8aa684c29679eded1e843d"
@@ -8168,16 +8106,6 @@ react-themeable@^1.1.0:
   dependencies:
     object-assign "^3.0.0"
 
-react-transition-group@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-1.2.1.tgz#e11f72b257f921b213229a774df46612346c7ca6"
-  dependencies:
-    chain-function "^1.0.0"
-    dom-helpers "^3.2.0"
-    loose-envify "^1.3.1"
-    prop-types "^15.5.6"
-    warning "^3.0.0"
-
 react-transition-group@^2.2.1:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.4.0.tgz#1d9391fabfd82e016f26fabd1eec329dbd922b5a"
@@ -8317,15 +8245,6 @@ rechoir@^0.6.2:
   dependencies:
     resolve "^1.1.6"
 
-recompose@^0.26.0:
-  version "0.26.0"
-  resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.26.0.tgz#9babff039cb72ba5bd17366d55d7232fbdfb2d30"
-  dependencies:
-    change-emitter "^0.1.2"
-    fbjs "^0.8.1"
-    hoist-non-react-statics "^2.3.1"
-    symbol-observable "^1.0.4"
-
 recompose@^0.29.0:
   version "0.29.0"
   resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.29.0.tgz#f1a4e20d5f24d6ef1440f83924e821de0b1bccef"
@@ -8402,7 +8321,7 @@ regenerator-runtime@^0.10.5:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
 
-regenerator-runtime@^0.11.0, regenerator-runtime@^0.11.1:
+regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
 
@@ -8900,10 +8819,6 @@ sigmund@~1.0.0:
 signal-exit@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
-
-simple-assign@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/simple-assign/-/simple-assign-0.1.0.tgz#17fd3066a5f3d7738f50321bb0f14ca281cc4baa"
 
 sinon-chai@~2.8.0:
   version "2.8.0"


### PR DESCRIPTION
Updates the last few imports that are used to create the theme that is provided through react-redux-provide. Removes the dependency on material-ui. The migration to `@material-ui/core` is complete!